### PR TITLE
Urlparse benchmarker

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -186,5 +186,21 @@ def itemloader(obj):
         obj.upload_result,
         obj.vmprof)
 
+
+@cli.command()
+@click.pass_obj
+def urlparseprofile(obj):
+    """Urlparse benchmarker"""
+    arg = "urlparseprofile.py"
+
+    calculator(
+        "Urlparse benchmarker",
+        arg,
+        obj.n_runs,
+        obj.only_result,
+        obj.upload_result,
+        obj.vmprof)
+
+
 if __name__ == '__main__':
     cli()

--- a/urlparseprofile.py
+++ b/urlparseprofile.py
@@ -1,0 +1,74 @@
+from timeit import default_timer as timer
+import tarfile
+
+import scrapy
+import click
+import six
+from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
+                                    urldefrag, urlencode, urlparse,
+                                    quote, parse_qs, parse_qsl,
+                                    ParseResult, unquote, urlunparse)
+from scrapy.crawler import CrawlerProcess
+
+
+def urljoin_rfc(base, ref, encoding='utf-8'):
+    r"""
+    .. warning::
+
+        This function is deprecated and will be removed in future.
+        It is not supported with Python 3.
+        Please use ``urlparse.urljoin`` instead.
+
+    Same as urlparse.urljoin but supports unicode values in base and ref
+    parameters (in which case they will be converted to str using the given
+    encoding).
+
+    Always returns a str.
+
+    >>> import w3lib.url
+    >>> w3lib.url.urljoin_rfc('http://www.example.com/path/index.html', u'/otherpath/index2.html')
+    'http://www.example.com/otherpath/index2.html'
+    >>>
+
+    >>> # Note: the following does not work in Python 3
+    >>> w3lib.url.urljoin_rfc(b'http://www.example.com/path/index.html', u'fran\u00e7ais/d\u00e9part.htm') # doctest: +SKIP
+    'http://www.example.com/path/fran\xc3\xa7ais/d\xc3\xa9part.htm'
+    >>>
+
+
+    """
+
+    warnings.warn("w3lib.url.urljoin_rfc is deprecated, use urlparse.urljoin instead",
+        DeprecationWarning)
+
+    str_base = to_bytes(base, encoding)
+    str_ref = to_bytes(ref, encoding)
+    return urljoin(str_base, str_ref)
+    
+
+def main():
+    total = 0
+    time = 0
+    tar = tarfile.open("bookfiles.tar.gz")
+
+    for member in tar.getmembers():
+        f = tar.extractfile(member)
+        html = f.read()
+        response = HtmlResponse(url="local", body=html, encoding='utf8')
+
+
+
+
+
+
+    print("\nTotal number of items extracted = {0}".format(total))
+    print("Time taken = {0}".format(time))
+    click.secho("Rate of link extraction : {0} items/second\n".format(
+        float(total / time)), bold=True)
+
+    with open("Benchmark.txt", 'w') as g:
+        g.write(" {0}".format((float(total / time))))
+
+
+if __name__ == "__main__":
+    main()

--- a/urlparseprofile.py
+++ b/urlparseprofile.py
@@ -16,6 +16,10 @@ def urljoin_profile(base, ref):
 def main():
     total = 0
     time = 0
+    time_file_uri_to_path = 0
+    time_safe_url_string = 0
+    time_canonicalize_url = 0
+
     tar = tarfile.open("sites.tar.gz")
     urls = []
 
@@ -28,20 +32,33 @@ def main():
         urls.extend(links)
 
     for url in urls:
-        start = timer()
-
+        start_file_uri_to_path = timer()
         file_uri_to_path(url)
+        end_file_uri_to_path = timer()
+        time_file_uri_to_path += (end_file_uri_to_path - start_file_uri_to_path)
+        time += (end_file_uri_to_path - start_file_uri_to_path)
+
+        start_safe_url_string = timer()
         safe_url_string(url)
+        end_safe_url_string = timer()
+        time_safe_url_string += (end_safe_url_string - start_safe_url_string)
+        time += (end_safe_url_string - start_safe_url_string)
+
+        start_canonicalize_url = timer()
         canonicalize_url(url)
-        # any_to_uri(url) Error on Python 2: KeyError: u'\u9996'
+        end_canonicalize_url = timer()
+        time_canonicalize_url += (end_canonicalize_url - start_canonicalize_url)
+        time += (end_canonicalize_url - start_canonicalize_url)
 
-        end = timer()
+        # any_to_uri(url) # Error on Python 2: KeyError: u'\u9996'
+
         total += 1
-        time = time + end - start
-
 
     print("\nTotal number of items extracted = {0}".format(total))
-    print("Time taken = {0}".format(time))
+    print("Time spent on file_uri_to_path = {0}".format(time_file_uri_to_path))
+    print("Time spent on safe_url_string = {0}".format(time_safe_url_string))
+    print("Time spent on canonicalize_url = {0}".format(time_canonicalize_url))
+    print("Total time taken = {0}".format(time))
     click.secho("Rate of link extraction : {0} items/second\n".format(
         float(total / time)), bold=True)
 

--- a/urlparseprofile.py
+++ b/urlparseprofile.py
@@ -4,11 +4,8 @@ import tarfile
 import scrapy
 import click
 import six
-from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
-                                    urldefrag, urlencode, urlparse,
-                                    quote, parse_qs, parse_qsl,
-                                    ParseResult, unquote, urlunparse)
-from scrapy.crawler import CrawlerProcess
+from w3lib.url import (parse_data_uri, file_uri_to_path, safe_url_string,
+                       canonicalize_url, any_to_uri)
 from scrapy.http import HtmlResponse
 
 
@@ -20,24 +17,36 @@ def main():
     total = 0
     time = 0
     tar = tarfile.open("sites.tar.gz")
+    urls = []
 
     for member in tar.getmembers():
         f = tar.extractfile(member)
         html = f.read()
         response = HtmlResponse(url="local", body=html, encoding='utf8')
 
-        urls = response.css('a::attr(href)').extract()
+        links = response.css('a::attr(href)').extract()
+        urls.extend(links)
+
+    for url in urls:
+        start = timer()
+
+        file_uri_to_path(url)
+        safe_url_string(url)
+        canonicalize_url(url)
+        # any_to_uri(url) Error on Python 2: KeyError: u'\u9996'
+
+        end = timer()
+        total += 1
+        time = time + end - start
 
 
-        print(urls)
+    print("\nTotal number of items extracted = {0}".format(total))
+    print("Time taken = {0}".format(time))
+    click.secho("Rate of link extraction : {0} items/second\n".format(
+        float(total / time)), bold=True)
 
-    # print("\nTotal number of items extracted = {0}".format(total))
-    # print("Time taken = {0}".format(time))
-    # click.secho("Rate of link extraction : {0} items/second\n".format(
-    #     float(total / time)), bold=True)
-    #
-    # with open("Benchmark.txt", 'w') as g:
-    #     g.write(" {0}".format((float(total / time))))
+    with open("Benchmark.txt", 'w') as g:
+        g.write(" {0}".format((float(total / time))))
 
 
 if __name__ == "__main__":

--- a/urlparseprofile.py
+++ b/urlparseprofile.py
@@ -9,65 +9,35 @@ from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
                                     quote, parse_qs, parse_qsl,
                                     ParseResult, unquote, urlunparse)
 from scrapy.crawler import CrawlerProcess
+from scrapy.http import HtmlResponse
 
 
-def urljoin_rfc(base, ref, encoding='utf-8'):
-    r"""
-    .. warning::
+def urljoin_profile(base, ref):
+    return urljoin(base, ref)
 
-        This function is deprecated and will be removed in future.
-        It is not supported with Python 3.
-        Please use ``urlparse.urljoin`` instead.
-
-    Same as urlparse.urljoin but supports unicode values in base and ref
-    parameters (in which case they will be converted to str using the given
-    encoding).
-
-    Always returns a str.
-
-    >>> import w3lib.url
-    >>> w3lib.url.urljoin_rfc('http://www.example.com/path/index.html', u'/otherpath/index2.html')
-    'http://www.example.com/otherpath/index2.html'
-    >>>
-
-    >>> # Note: the following does not work in Python 3
-    >>> w3lib.url.urljoin_rfc(b'http://www.example.com/path/index.html', u'fran\u00e7ais/d\u00e9part.htm') # doctest: +SKIP
-    'http://www.example.com/path/fran\xc3\xa7ais/d\xc3\xa9part.htm'
-    >>>
-
-
-    """
-
-    warnings.warn("w3lib.url.urljoin_rfc is deprecated, use urlparse.urljoin instead",
-        DeprecationWarning)
-
-    str_base = to_bytes(base, encoding)
-    str_ref = to_bytes(ref, encoding)
-    return urljoin(str_base, str_ref)
-    
 
 def main():
     total = 0
     time = 0
-    tar = tarfile.open("bookfiles.tar.gz")
+    tar = tarfile.open("sites.tar.gz")
 
     for member in tar.getmembers():
         f = tar.extractfile(member)
         html = f.read()
         response = HtmlResponse(url="local", body=html, encoding='utf8')
 
+        urls = response.css('a::attr(href)').extract()
 
 
+        print(urls)
 
-
-
-    print("\nTotal number of items extracted = {0}".format(total))
-    print("Time taken = {0}".format(time))
-    click.secho("Rate of link extraction : {0} items/second\n".format(
-        float(total / time)), bold=True)
-
-    with open("Benchmark.txt", 'w') as g:
-        g.write(" {0}".format((float(total / time))))
+    # print("\nTotal number of items extracted = {0}".format(total))
+    # print("Time taken = {0}".format(time))
+    # click.secho("Rate of link extraction : {0} items/second\n".format(
+    #     float(total / time)), bold=True)
+    #
+    # with open("Benchmark.txt", 'w') as g:
+    #     g.write(" {0}".format((float(total / time))))
 
 
 if __name__ == "__main__":

--- a/urlparseprofile.py
+++ b/urlparseprofile.py
@@ -9,10 +9,6 @@ from w3lib.url import (parse_data_uri, file_uri_to_path, safe_url_string,
 from scrapy.http import HtmlResponse
 
 
-def urljoin_profile(base, ref):
-    return urljoin(base, ref)
-
-
 def main():
     total = 0
     time = 0


### PR DESCRIPTION
Hey guys, I made a benchmarker for functions in w3lib that heavily use urlparse library. I got the following result when using this benchmarker:
Python2:
```
Total number of items extracted = 32799
Time taken = 1.52635908127
Rate of link extraction : 21488.3905121 items/second
```

Python3:
```
Total number of items extracted = 32799
Time taken = 2.80625425944163
Rate of link extraction : 11687.821903395927 items/second
```

Which is as I expected. If you have any suggestion, please let me know :)