### PR TITLE
Use appropriate for broadcrawl priority queue

### DIFF
--- a/broad/broad/settings.py
+++ b/broad/broad/settings.py
@@ -17,6 +17,8 @@ CONCURRENT_REQUESTS = 120
 AUTOTHROTTLE_ENABLED = True
 REACTOR_THREADPOOL_MAXSIZE = 20
 
+SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'
+
 try:
     from .local_settings import *
 except ImportError:


### PR DESCRIPTION
It was shown in https://github.com/scrapy/scrapy/pull/3520 `DownloaderAwarePriorityQueue` provides 10x improvement in speed for broadcrawls so we should use it by default for `broadworm`